### PR TITLE
[TIMESERIES-FEATURES] Adding a Datetime encoder/decoder

### DIFF
--- a/api/src/main/java/com/ovh/mls/serving/runtime/swagger/SwaggerBuilder.java
+++ b/api/src/main/java/com/ovh/mls/serving/runtime/swagger/SwaggerBuilder.java
@@ -54,9 +54,9 @@ public class SwaggerBuilder {
     private static final String OUTPUT_TENSORS = "Outputs";
 
     private final Config config;
-    private final Evaluator evaluator;
+    private final Evaluator<?> evaluator;
 
-    public SwaggerBuilder(Config config, Evaluator evaluator) {
+    public SwaggerBuilder(Config config, Evaluator<?> evaluator) {
         this.config = config;
         this.evaluator = evaluator;
     }
@@ -96,7 +96,7 @@ public class SwaggerBuilder {
     }
 
     private void buildResponse(Components components) throws JsonProcessingException {
-        List<Field> outputs = evaluator.getOutputs();
+        List<? extends Field> outputs = evaluator.getOutputs();
         MediaType jsonMediaType = new MediaType();
 
         // We build the schema with the output fields
@@ -160,7 +160,7 @@ public class SwaggerBuilder {
 
     private void buildRequest(Components components) throws JsonProcessingException {
 
-        List<Field> inputs = evaluator.getInputs();
+        List<? extends Field> inputs = evaluator.getInputs();
         MediaType jsonMediaType = new MediaType();
         jsonMediaType.schema(new Schema().$ref(INPUT_TENSORS));
 
@@ -222,7 +222,7 @@ public class SwaggerBuilder {
             .addSchemas(OUTPUT_TENSORS, outputTensorsSchema);
     }
 
-    private static Schema<?> buildMultipartSchema(List<Field> fields) {
+    private static Schema<?> buildMultipartSchema(List<? extends Field> fields) {
         Schema multipartFormat = new Schema().type("object");
         Map<String, Schema<?>> schemas = new HashMap<>();
         for (Field field : fields) {
@@ -241,7 +241,7 @@ public class SwaggerBuilder {
     }
 
     private static String getDescription(
-            List<Field> fields,
+            List<? extends Field> fields,
             String description1,
             String description2,
             TensorIO tensorIO) {
@@ -282,7 +282,7 @@ public class SwaggerBuilder {
         return description.toString();
     }
 
-    private Schema buildSchemaFromFields(List<Field> fields) {
+    private Schema buildSchemaFromFields(List<? extends Field> fields) {
         Schema schema = new ObjectSchema();
 
         fields.forEach(
@@ -413,7 +413,7 @@ public class SwaggerBuilder {
         return new Schema();
     }
 
-    private TensorIO generateRandomTensors(List<Field> fields) {
+    private TensorIO generateRandomTensors(List<? extends Field> fields) {
         Map<String, Tensor> result = new HashMap<>();
         for (Field field: fields) {
             Tensor tensor = generateRandomTensor(field, 1);

--- a/commons/src/main/java/com/ovh/mls/serving/runtime/core/AbstractEvaluatorManifest.java
+++ b/commons/src/main/java/com/ovh/mls/serving/runtime/core/AbstractEvaluatorManifest.java
@@ -3,25 +3,25 @@ package com.ovh.mls.serving.runtime.core;
 import java.util.ArrayList;
 import java.util.List;
 
-public abstract class AbstractEvaluatorManifest implements EvaluatorManifest {
+public abstract class AbstractEvaluatorManifest<F extends Field> implements EvaluatorManifest {
 
-    private List<Field> inputs = new ArrayList<>();
-    private List<Field> outputs = new ArrayList<>();
+    private List<F> inputs = new ArrayList<>();
+    private List<F> outputs = new ArrayList<>();
 
-    public List<Field> getInputs() {
+    public List<F> getInputs() {
         return inputs;
     }
 
-    public AbstractEvaluatorManifest setInputs(List<Field> inputs) {
+    public AbstractEvaluatorManifest<F> setInputs(List<F> inputs) {
         this.inputs = inputs;
         return this;
     }
 
-    public List<Field> getOutputs() {
+    public List<F> getOutputs() {
         return outputs;
     }
 
-    public AbstractEvaluatorManifest setOutputs(List<Field> outputs) {
+    public AbstractEvaluatorManifest<F> setOutputs(List<F> outputs) {
         this.outputs = outputs;
         return this;
     }

--- a/commons/src/main/java/com/ovh/mls/serving/runtime/core/AbstractTensorEvaluator.java
+++ b/commons/src/main/java/com/ovh/mls/serving/runtime/core/AbstractTensorEvaluator.java
@@ -12,18 +12,18 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
-public abstract class AbstractTensorEvaluator implements Evaluator {
+public abstract class AbstractTensorEvaluator<F extends TensorField> implements Evaluator<F> {
 
     private final int rollingWindowsSize;
 
-    private final List<TensorField> inputTensorFields;
-    private final List<TensorField> outputTensorFields;
+    private final List<F> inputTensorFields;
+    private final List<F> outputTensorFields;
     private final Builder<TensorIO, TensorIO> inputTensorBuilder;
     private final Builder<TensorIO, TensorIO> outputTensorBuilder;
 
     public AbstractTensorEvaluator(
-        List<TensorField> inputTensorFields,
-        List<TensorField> outputTensorFields,
+        List<F> inputTensorFields,
+        List<F> outputTensorFields,
         int rollingWindowsSize
     ) {
         this.rollingWindowsSize = rollingWindowsSize;
@@ -65,13 +65,13 @@ public abstract class AbstractTensorEvaluator implements Evaluator {
     protected abstract TensorIO evaluateTensor(TensorIO tensorIO) throws EvaluationException;
 
     @Override
-    public List<Field> getInputs() {
-        return new ArrayList<>(this.inputTensorFields);
+    public List<F> getInputs() {
+        return new ArrayList<F>(this.inputTensorFields);
     }
 
     @Override
-    public List<Field> getOutputs() {
-        return new ArrayList<>(this.outputTensorFields);
+    public List<F> getOutputs() {
+        return new ArrayList<F>(this.outputTensorFields);
     }
 
     @Override
@@ -80,12 +80,12 @@ public abstract class AbstractTensorEvaluator implements Evaluator {
     }
 
     @Transient
-    public List<TensorField> getInputTensorField() {
+    public List<? extends TensorField> getInputTensorField() {
         return this.inputTensorFields;
     }
 
     @Transient
-    public List<TensorField> getOutputTensorField() {
+    public List<? extends TensorField> getOutputTensorField() {
         return this.outputTensorFields;
     }
 

--- a/commons/src/main/java/com/ovh/mls/serving/runtime/core/Evaluator.java
+++ b/commons/src/main/java/com/ovh/mls/serving/runtime/core/Evaluator.java
@@ -6,7 +6,7 @@ import com.ovh.mls.serving.runtime.exceptions.EvaluationException;
 
 import java.util.List;
 
-public interface Evaluator {
+public interface Evaluator<F extends Field> {
     /**
      * Applies the evaluator operations over a Table and returns the initial
      * Table enriched with generated outputs.
@@ -20,13 +20,13 @@ public interface Evaluator {
      * @return The list of inputs required by the evaluator
      */
     @JsonProperty("inputs")
-    List<Field> getInputs();
+    List<F> getInputs();
 
     /**
      * @return The list of outputs added to the Table after applying the evaluator
      */
     @JsonProperty("outputs")
-    List<Field> getOutputs();
+    List<F> getOutputs();
 
     /**
      * @return The required number of rows in the Table for the evaluator

--- a/commons/src/main/java/com/ovh/mls/serving/runtime/core/builder/TensorIOIntoTensorIO.java
+++ b/commons/src/main/java/com/ovh/mls/serving/runtime/core/builder/TensorIOIntoTensorIO.java
@@ -24,7 +24,7 @@ public class TensorIOIntoTensorIO implements Builder<TensorIO, TensorIO> {
     /**
      * List of tensor fields to use for transformation
      */
-    private final List<TensorField> tensorFields;
+    private final List<? extends TensorField> tensorFields;
 
     /**
      * Indicates if the output tensors should be the main tensor or the computed index for that tensor
@@ -36,16 +36,16 @@ public class TensorIOIntoTensorIO implements Builder<TensorIO, TensorIO> {
      */
     private final int rollingWindowsSize;
 
-    public TensorIOIntoTensorIO(List<TensorField> tensorFields) {
+    public TensorIOIntoTensorIO(List<? extends TensorField> tensorFields) {
         this(tensorFields, false, 1);
     }
 
-    public TensorIOIntoTensorIO(List<TensorField> tensorFields, boolean buildIndexes) {
+    public TensorIOIntoTensorIO(List<? extends TensorField> tensorFields, boolean buildIndexes) {
         this(tensorFields, buildIndexes, 1);
     }
 
     public TensorIOIntoTensorIO(
-        List<TensorField> tensorFields,
+        List<? extends TensorField> tensorFields,
         boolean buildIndexes,
         int rollingWindowsSize) {
 

--- a/commons/src/main/java/com/ovh/mls/serving/runtime/core/tensor/Tensor.java
+++ b/commons/src/main/java/com/ovh/mls/serving/runtime/core/tensor/Tensor.java
@@ -8,6 +8,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
+import java.util.function.Function;
 import java.util.stream.IntStream;
 
 public class Tensor {
@@ -748,5 +749,15 @@ public class Tensor {
         } else {
             return this.getData();
         }
+    }
+
+    public <T> Tensor apply(Function<Object, T> func, DataType outputDataType) {
+        Tensor outputTensor = new Tensor(outputDataType, this.shape);
+        this.coordIterator().forEachRemaining(coords -> {
+            Object input = this.getCoord(coords);
+            T output = func.apply(input);
+            outputTensor.setOnCoord(output, coords);
+        });
+        return outputTensor;
     }
 }

--- a/commons/src/main/java/com/ovh/mls/serving/runtime/utils/img/ImageDefaults.java
+++ b/commons/src/main/java/com/ovh/mls/serving/runtime/utils/img/ImageDefaults.java
@@ -203,7 +203,7 @@ public class ImageDefaults {
         return maybeBuilder.get();
     }
 
-    public static boolean supportSingleImageConversion(List<Field> fields) {
+    public static boolean supportSingleImageConversion(List<? extends Field> fields) {
         if (fields.size() == 1) {
             Field field = fields.get(0);
             if (field instanceof TensorField) {

--- a/commons/src/main/java/com/ovh/mls/serving/runtime/validation/Validator.java
+++ b/commons/src/main/java/com/ovh/mls/serving/runtime/validation/Validator.java
@@ -16,7 +16,7 @@ public class Validator {
      * @param evaluator instance to check
      * @throws EvaluatorException if one check fails an exception is thrown
      */
-    public static void validate(Evaluator evaluator) throws EvaluatorException {
+    public static void validate(Evaluator<?> evaluator) throws EvaluatorException {
         if (evaluator.getClass().isAnnotationPresent(NumberOnly.class)) {
             checkNumbers(evaluator);
         }
@@ -29,7 +29,7 @@ public class Validator {
      * @param evaluator evaluator only supporting Number input
      * @throws EvaluatorException throws an exception if one field is not a Number type
      */
-    private static void checkNumbers(Evaluator evaluator) throws EvaluatorException {
+    private static void checkNumbers(Evaluator<?> evaluator) throws EvaluatorException {
 
         String nonNumberFields = evaluator.getInputs().stream()
             .filter(field -> !DataType.isNumberType(field.getType()))

--- a/evaluator-onnx/src/main/java/com/ovh/mls/serving/runtime/onnx/OnnxEvaluator.java
+++ b/evaluator-onnx/src/main/java/com/ovh/mls/serving/runtime/onnx/OnnxEvaluator.java
@@ -32,7 +32,7 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 
 
-public class OnnxEvaluator extends AbstractTensorEvaluator {
+public class OnnxEvaluator extends AbstractTensorEvaluator<TensorField> {
     private static final OrtEnvironment ONNX_ENVIRONMENT;
 
     static {

--- a/evaluator-processors/src/main/java/com/ovh/mls/serving/runtime/processors/StandardScalerManifest.java
+++ b/evaluator-processors/src/main/java/com/ovh/mls/serving/runtime/processors/StandardScalerManifest.java
@@ -2,6 +2,7 @@ package com.ovh.mls.serving.runtime.processors;
 
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.ovh.mls.serving.runtime.core.AbstractEvaluatorManifest;
+import com.ovh.mls.serving.runtime.core.Field;
 import com.ovh.mls.serving.runtime.core.IncludeAsEvaluatorManifest;
 import com.ovh.mls.serving.runtime.exceptions.EvaluatorException;
 
@@ -9,7 +10,7 @@ import java.util.Map;
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.NONE)
 @IncludeAsEvaluatorManifest(type = "standard_scaler")
-public class StandardScalerManifest extends AbstractEvaluatorManifest {
+public class StandardScalerManifest extends AbstractEvaluatorManifest<Field> {
 
     private static final String type = "standard_scaler";
 

--- a/evaluator-tensorflow/src/main/java/com/ovh/mls/serving/runtime/tensorflow/TensorflowEvaluator.java
+++ b/evaluator-tensorflow/src/main/java/com/ovh/mls/serving/runtime/tensorflow/TensorflowEvaluator.java
@@ -29,7 +29,7 @@ import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
 
 @NumberOnly
-public class TensorflowEvaluator extends AbstractTensorEvaluator {
+public class TensorflowEvaluator extends AbstractTensorEvaluator<TensorField> {
     private static final Logger LOGGER = LoggerFactory.getLogger(TensorflowEvaluator.class);
 
     /**

--- a/evaluator-tensorflow/src/test/java/com/ovh/mls/serving/runtime/tensorflow/H5Test.java
+++ b/evaluator-tensorflow/src/test/java/com/ovh/mls/serving/runtime/tensorflow/H5Test.java
@@ -7,6 +7,7 @@ import com.ovh.mls.serving.runtime.core.Field;
 import com.ovh.mls.serving.runtime.core.builder.InputStreamJsonIntoTensorIO;
 import com.ovh.mls.serving.runtime.core.io.TensorIO;
 import com.ovh.mls.serving.runtime.core.tensor.Tensor;
+import com.ovh.mls.serving.runtime.core.tensor.TensorField;
 import com.ovh.mls.serving.runtime.core.tensor.TensorShape;
 import com.ovh.mls.serving.runtime.exceptions.EvaluationException;
 import com.ovh.mls.serving.runtime.exceptions.EvaluatorException;
@@ -57,7 +58,7 @@ public class H5Test {
 
     @Test
     public void getInputs() {
-        List<Field> inputs = tensorFlowEvaluator.getInputs();
+        List<TensorField> inputs = tensorFlowEvaluator.getInputs();
         assertEquals(1, inputs.size());
         assertEquals("inputs", inputs.get(0).getName());
         assertEquals(DataType.FLOAT, inputs.get(0).getType());
@@ -65,7 +66,7 @@ public class H5Test {
 
     @Test
     public void getOutputs() {
-        List<Field> outputs = tensorFlowEvaluator.getOutputs();
+        List<TensorField> outputs = tensorFlowEvaluator.getOutputs();
 
         assertEquals(1, outputs.size());
 

--- a/evaluator-timeseries/src/main/java/com/ovh/mls/serving/runtime/timeseries/DateTensorField.java
+++ b/evaluator-timeseries/src/main/java/com/ovh/mls/serving/runtime/timeseries/DateTensorField.java
@@ -1,0 +1,103 @@
+package com.ovh.mls.serving.runtime.timeseries;
+
+import com.ovh.mls.serving.runtime.core.tensor.TensorField;
+import com.ovh.mls.serving.runtime.exceptions.EvaluationException;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeFormatterBuilder;
+import java.time.temporal.ChronoField;
+import java.util.function.Function;
+
+/**
+ * Specific TensorField supporting LocalDateTime interpretation and encoding for each tensor's value
+ */
+public class DateTensorField extends TensorField {
+
+    /**
+     * String representation the LocalDateTimeEncoder needed if this field as a numeric type, represente the string
+     * formatter of the LocalDateTime otherwise
+     */
+    private String format;
+
+    /**
+     * Default constructor of DateTensorField
+     */
+    public DateTensorField() {
+
+    }
+
+    /**
+     * Accessor of format string
+     */
+    public String getFormat() {
+        return format;
+    }
+
+    /**
+     * Setter of format string
+     */
+    public void setFormat(String format) {
+        this.format = format;
+    }
+
+    /**
+     * Create the decode function needed by this field to be interpreted as a LocalDateTime
+     */
+    public Function<Object, LocalDateTime> decodeDatetimeFunction() {
+        switch (this.getType()) {
+            case DOUBLE:
+            case FLOAT:
+            case INTEGER:
+            case LONG:
+                return x -> LocalDateTimeEncoder.fromString(this.getFormat()).decode(((Number) x).longValue());
+            case STRING:
+                DateTimeFormatter formatter = timeFormatter(this.getFormat());
+                return x -> LocalDateTime.from(formatter.parse((String) x));
+            case DATE:
+                return x -> (LocalDateTime) x;
+            default:
+                throw new EvaluationException("Datetime evaluator only support numeric & string formats as inputs");
+        }
+    }
+
+    /**
+     * Create the encode function needed by this field so that the LocalDateTime can be correctly encoded
+     */
+    public Function<LocalDateTime, Object> encodeDatetimeFunction() {
+        String format = this.getFormat();
+        switch (this.getType()) {
+            case DOUBLE:
+                return x -> LocalDateTimeEncoder.fromString(format).encode(x).doubleValue();
+            case FLOAT:
+                return x -> LocalDateTimeEncoder.fromString(format).encode(x).floatValue();
+            case INTEGER:
+                return x -> LocalDateTimeEncoder.fromString(format).encode(x).intValue();
+            case LONG:
+                return x -> LocalDateTimeEncoder.fromString(format).encode(x);
+            case STRING:
+                DateTimeFormatter outputFormatter = timeFormatter(format);
+                return outputFormatter::format;
+            case DATE:
+                return x -> x;
+            default:
+                throw new EvaluationException("Datetime evaluator only support numeric & string formats as inputs");
+        }
+    }
+
+    /**
+     * Create a default DateTimeFormatter for LocalDateTime string interpretations
+     * @param format the string formatter to use in the DateTimeFormatter
+     */
+    private static DateTimeFormatter timeFormatter(String format) {
+        return new DateTimeFormatterBuilder()
+            .appendPattern(format)
+            .parseDefaulting(ChronoField.MONTH_OF_YEAR, 1)
+            .parseDefaulting(ChronoField.DAY_OF_MONTH, 1)
+            .parseDefaulting(ChronoField.HOUR_OF_DAY, 0)
+            .parseDefaulting(ChronoField.MINUTE_OF_HOUR, 0)
+            .parseDefaulting(ChronoField.SECOND_OF_MINUTE, 0)
+            .toFormatter();
+    }
+
+}

--- a/evaluator-timeseries/src/main/java/com/ovh/mls/serving/runtime/timeseries/DatetimeEvaluator.java
+++ b/evaluator-timeseries/src/main/java/com/ovh/mls/serving/runtime/timeseries/DatetimeEvaluator.java
@@ -1,0 +1,57 @@
+package com.ovh.mls.serving.runtime.timeseries;
+
+import com.ovh.mls.serving.runtime.core.AbstractTensorEvaluator;
+import com.ovh.mls.serving.runtime.core.io.TensorIO;
+import com.ovh.mls.serving.runtime.core.tensor.Tensor;
+import com.ovh.mls.serving.runtime.exceptions.EvaluationException;
+import com.ovh.mls.serving.runtime.exceptions.EvaluatorException;
+
+import java.time.LocalDateTime;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+
+/**
+ * Evaluator used to encode and decode datetimes, it takes only one input which is the date to decode
+ * It can answer with several output, each one representing a configured encoded value for the input date
+ */
+public class DatetimeEvaluator extends AbstractTensorEvaluator<DateTensorField> {
+
+    private final DateTensorField singleInput;
+
+    public DatetimeEvaluator(
+        List<DateTensorField> inputs,
+        List<DateTensorField> outputs
+    ) {
+        super(inputs, outputs, 1);
+        if (inputs.size() != 1) {
+            throw new EvaluatorException("There should be only 1 input for a datetime evaluator");
+        }
+        this.singleInput = this.getInputs().get(0);
+    }
+
+    @Override
+    protected TensorIO evaluateTensor(TensorIO tensorIO) throws EvaluationException {
+        String inputTensorName = this.singleInput.getName();
+        Tensor inputTensor = tensorIO.getTensor(inputTensorName);
+        if (inputTensor == null) {
+            throw new EvaluationException(String.format("Impossible to find a tensor with name '%s'", inputTensorName));
+        }
+        if (this.singleInput.getType() != inputTensor.getType()) {
+            throw new EvaluationException(
+                String.format("Input type for tensor %s is different from given one", inputTensorName));
+        }
+
+        Function<Object, LocalDateTime> decodeFunction = this.singleInput.decodeDatetimeFunction();
+        Map<String, Tensor> outputsTensors = new HashMap<>();
+        for (DateTensorField outputsField : this.getOutputs()) {
+            Function<LocalDateTime, Object> encodeFunction = outputsField.encodeDatetimeFunction();
+            Function<Object, Object> fullTransfo = encodeFunction.compose(decodeFunction);
+            Tensor outputTensor = inputTensor.apply(fullTransfo, outputsField.getType());
+            outputsTensors.put(outputsField.getName(), outputTensor);
+        }
+        return new TensorIO(outputsTensors);
+    }
+
+}

--- a/evaluator-timeseries/src/main/java/com/ovh/mls/serving/runtime/timeseries/DatetimeEvaluatorManifest.java
+++ b/evaluator-timeseries/src/main/java/com/ovh/mls/serving/runtime/timeseries/DatetimeEvaluatorManifest.java
@@ -1,0 +1,25 @@
+package com.ovh.mls.serving.runtime.timeseries;
+
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.ovh.mls.serving.runtime.core.AbstractEvaluatorManifest;
+import com.ovh.mls.serving.runtime.core.IncludeAsEvaluatorManifest;
+import com.ovh.mls.serving.runtime.exceptions.EvaluatorException;
+
+// In case of direct deserialization we override parent JsonTypeInfo
+@JsonTypeInfo(use = JsonTypeInfo.Id.NONE)
+@IncludeAsEvaluatorManifest(type = DatetimeEvaluatorManifest.TYPE)
+public class DatetimeEvaluatorManifest extends AbstractEvaluatorManifest<DateTensorField> {
+
+    public static final String TYPE = "datetime_encoder";
+
+    @Override
+    public DatetimeEvaluator create(String path) throws EvaluatorException {
+        return new DatetimeEvaluator(this.getInputs(), this.getOutputs());
+    }
+
+    @Override
+    public String getType() {
+        return TYPE;
+    }
+
+}

--- a/evaluator-timeseries/src/main/java/com/ovh/mls/serving/runtime/timeseries/LocalDateTimeEncoder.java
+++ b/evaluator-timeseries/src/main/java/com/ovh/mls/serving/runtime/timeseries/LocalDateTimeEncoder.java
@@ -1,0 +1,99 @@
+package com.ovh.mls.serving.runtime.timeseries;
+
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.util.concurrent.TimeUnit;
+
+import static java.time.temporal.ChronoUnit.*;
+
+/**
+ * Encoders / Decoders for (LocalDateTime / Long)
+ */
+public enum LocalDateTimeEncoder {
+    // Numeric representation of the year
+    YEAR,
+    // Numeric representation of the month
+    MONTH,
+    // Numeric representation of the day of the month
+    DAYOFMONTH,
+    // Numeric representation of the day of the week
+    DAYOFWEEK,
+    // Numeric representation of the hour of the day
+    HOUROFDAY,
+    // Numeric representation of the minute of the hour
+    MINUTEOFHOUR,
+    // Timestamp UTC in years
+    TS_Y,
+    // Timestamp UTC in months
+    TS_MO,
+    // Timestamp UTC in days
+    TS_D,
+    // Timestamp UTC in hours
+    TS_H,
+    // Timestamp UTC in minutes
+    TS_MI,
+    // Timestamp UTC in seconds
+    TS_S,
+    // Timestamp UTC in milliseconds
+    TS_MS,
+    // Timestamp UTC in microseconds
+    TS_US,
+    // Timestamp UTC in nanoseconds
+    TS_NS;
+
+    private static final ZoneOffset REF_ZONE = ZoneOffset.UTC;
+    private static final LocalDateTime REF_DATETIME = LocalDateTime.ofInstant(Instant.ofEpochMilli(0), REF_ZONE);
+
+    public static LocalDateTimeEncoder fromString(String name) {
+        return valueOf(name.toUpperCase());
+    }
+
+    public LocalDateTime decode(long timestamp) {
+        switch(this) {
+            case TS_Y: return REF_DATETIME.plusYears(timestamp);
+            case TS_MO: return REF_DATETIME.plusMonths(timestamp);
+            case TS_D: return REF_DATETIME.plusDays(timestamp);
+            case TS_H: return REF_DATETIME.plusHours(timestamp);
+            case TS_MI: return REF_DATETIME.plusMinutes(timestamp);
+            case TS_S: return REF_DATETIME.plusSeconds(timestamp);
+            case TS_MS: return LocalDateTime.ofInstant(Instant.ofEpochMilli(timestamp), REF_ZONE);
+            case TS_US: return LocalDateTime.ofInstant(
+                Instant.ofEpochSecond(
+                    TimeUnit.MICROSECONDS.toSeconds(timestamp),
+                    TimeUnit.MICROSECONDS.toNanos(
+                        Math.floorMod(timestamp, TimeUnit.SECONDS.toMicros(1))
+                    )
+                ), REF_ZONE);
+            case TS_NS: return LocalDateTime.ofInstant(Instant.ofEpochSecond(0L, timestamp), REF_ZONE);
+            default:
+                throw new AssertionError(
+                    String.format("Impossible to construct a date from a %s only transformation", this));
+        }
+    }
+
+    public Long encode(LocalDateTime dateTime) {
+        switch(this) {
+            case YEAR: return (long) dateTime.getYear();
+            case MONTH: return (long) dateTime.getMonthValue();
+            case DAYOFMONTH: return (long) dateTime.getDayOfMonth();
+            case DAYOFWEEK: return (long) dateTime.getDayOfWeek().getValue();
+            case HOUROFDAY: return (long) dateTime.getHour();
+            case MINUTEOFHOUR: return (long) dateTime.getMinute();
+
+            case TS_Y: return YEARS.between(REF_DATETIME, dateTime);
+            case TS_MO: return MONTHS.between(REF_DATETIME, dateTime);
+            case TS_D: return WEEKS.between(REF_DATETIME, dateTime);
+            case TS_H: return HOURS.between(REF_DATETIME, dateTime);
+            case TS_MI: return MINUTES.between(REF_DATETIME, dateTime);
+
+            case TS_S: return SECONDS.between(REF_DATETIME, dateTime);
+            case TS_MS: return MILLIS.between(REF_DATETIME, dateTime);
+            case TS_US: return MICROS.between(REF_DATETIME, dateTime);
+            case TS_NS: return NANOS.between(REF_DATETIME, dateTime);
+        }
+        throw new AssertionError("Unknown operation : " + this);
+    }
+
+}
+

--- a/evaluator-timeseries/src/main/java/com/ovh/mls/serving/runtime/timeseries/PredictionIntervalEvaluatorManifest.java
+++ b/evaluator-timeseries/src/main/java/com/ovh/mls/serving/runtime/timeseries/PredictionIntervalEvaluatorManifest.java
@@ -3,6 +3,7 @@ package com.ovh.mls.serving.runtime.timeseries;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.ovh.mls.serving.runtime.core.AbstractEvaluatorManifest;
+import com.ovh.mls.serving.runtime.core.Field;
 import com.ovh.mls.serving.runtime.core.IncludeAsEvaluatorManifest;
 
 import java.util.Collections;
@@ -11,7 +12,7 @@ import java.util.Map;
 // In case of direct deserialization we override parent JsonTypeInfo
 @JsonTypeInfo(use = JsonTypeInfo.Id.NONE)
 @IncludeAsEvaluatorManifest(type = "pi")
-public class PredictionIntervalEvaluatorManifest extends AbstractEvaluatorManifest {
+public class PredictionIntervalEvaluatorManifest extends AbstractEvaluatorManifest<Field> {
 
     private static final String type = "pi";
 

--- a/evaluator-timeseries/src/test/java/com/ovh/mls/serving/runtime/timeseries/DatetimeEvaluatorTest.java
+++ b/evaluator-timeseries/src/test/java/com/ovh/mls/serving/runtime/timeseries/DatetimeEvaluatorTest.java
@@ -1,0 +1,126 @@
+package com.ovh.mls.serving.runtime.timeseries;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.ovh.mls.serving.runtime.core.DataType;
+import com.ovh.mls.serving.runtime.core.EvaluationContext;
+import com.ovh.mls.serving.runtime.core.io.TensorIO;
+import com.ovh.mls.serving.runtime.core.tensor.Tensor;
+import com.ovh.mls.serving.runtime.exceptions.EvaluationException;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.util.Map;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class DatetimeEvaluatorTest {
+
+    private static final ClassLoader LOADER = DatetimeEvaluatorTest.class.getClassLoader();
+
+    DatetimeEvaluator createEvaluator(String path) throws IOException {
+        ObjectMapper objectMapper = new ObjectMapper();
+        DatetimeEvaluatorManifest predictionIntervalEvaluatorManifest = objectMapper.readValue(
+            LOADER.getResourceAsStream(path),
+            DatetimeEvaluatorManifest.class
+        );
+        return predictionIntervalEvaluatorManifest.create("");
+    }
+
+    @Test
+    void evaluateTimestampManifest() throws IOException {
+        DatetimeEvaluator datetimeStringEval = createEvaluator("timeseries/datetime-timestamp-manifest.json");
+        TensorIO input = new TensorIO(
+            Map.of("timestamp-seconds", Tensor.fromLongData(new long[]{1514764800L, 1577836799L})));
+        TensorIO output = datetimeStringEval.evaluate(input, new EvaluationContext());
+        assertEquals(2, output.getBatchSize());
+        assertEquals(Set.of("date"), output.tensorsNames());
+        Tensor dateTensor = output.getTensor("date");
+        assertArrayEquals(new int[]{2, 1}, dateTensor.getShapeAsArray());
+        assertEquals(DataType.STRING, dateTensor.getType());
+        assertEquals("2018-01-01 00:00:00", ((String[][]) dateTensor.getData())[0][0]);
+        assertEquals("2019-12-31 23:59:59", ((String[][]) dateTensor.getData())[1][0]);
+    }
+
+    @Test
+    void evaluateDatetimeStringManifest() throws EvaluationException, IOException {
+        DatetimeEvaluator datetimeStringEval = createEvaluator("timeseries/datetime-string-manifest.json");
+        TensorIO input = new TensorIO(
+            Map.of("date", Tensor.fromStringData(new String[]{"2018-01-01 00:00:00", "2019-12-31 23:59:59"})));
+        TensorIO output = datetimeStringEval.evaluate(input, new EvaluationContext());
+
+        assertEquals(2, output.getBatchSize());
+        assertEquals(
+            Set.of(
+                "year",
+                "month",
+                "dayofmonth",
+                "hourofday",
+                "minuteofhour",
+                "dayofweek",
+                "year-string",
+                "year-float",
+                "timestamp-seconds",
+                "timestamp-years"
+            ),
+            output.tensorsNames()
+        );
+        Tensor yearTensor = output.getTensor("year");
+        Tensor monthTensor = output.getTensor("month");
+        Tensor dayOfMonthTensor = output.getTensor("dayofmonth");
+        Tensor hourofdayTensor = output.getTensor("hourofday");
+        Tensor minuteofhourTensor = output.getTensor("minuteofhour");
+        Tensor dayofweekTensor = output.getTensor("dayofweek");
+        Tensor yearString = output.getTensor("year-string");
+        Tensor yearFloat = output.getTensor("year-float");
+        Tensor timestampSeconds = output.getTensor("timestamp-seconds");
+        Tensor timestampYears = output.getTensor("timestamp-years");
+
+        // Check shapes
+        assertArrayEquals(new int[]{2, 1}, yearTensor.getShapeAsArray());
+        assertArrayEquals(new int[]{2, 1}, monthTensor.getShapeAsArray());
+        assertArrayEquals(new int[]{2, 1}, dayOfMonthTensor.getShapeAsArray());
+        assertArrayEquals(new int[]{2, 1}, hourofdayTensor.getShapeAsArray());
+        assertArrayEquals(new int[]{2, 1}, minuteofhourTensor.getShapeAsArray());
+        assertArrayEquals(new int[]{2, 1}, dayofweekTensor.getShapeAsArray());
+        assertArrayEquals(new int[]{2, 1}, yearString.getShapeAsArray());
+        assertArrayEquals(new int[]{2, 1}, yearFloat.getShapeAsArray());
+        assertArrayEquals(new int[]{2, 1}, timestampSeconds.getShapeAsArray());
+        assertArrayEquals(new int[]{2, 1}, timestampYears.getShapeAsArray());
+
+        // Check data types
+        assertEquals(DataType.INTEGER, yearTensor.getType());
+        assertEquals(DataType.INTEGER, monthTensor.getType());
+        assertEquals(DataType.INTEGER, dayOfMonthTensor.getType());
+        assertEquals(DataType.INTEGER, hourofdayTensor.getType());
+        assertEquals(DataType.INTEGER, minuteofhourTensor.getType());
+        assertEquals(DataType.INTEGER, dayofweekTensor.getType());
+        assertEquals(DataType.STRING, yearString.getType());
+        assertEquals(DataType.FLOAT, yearFloat.getType());
+        assertEquals(DataType.LONG, timestampSeconds.getType());
+        assertEquals(DataType.LONG, timestampYears.getType());
+
+        assertEquals(2018, ((int[][]) yearTensor.getData())[0][0]);
+        assertEquals(1, ((int[][]) monthTensor.getData())[0][0]);
+        assertEquals(1, ((int[][]) dayOfMonthTensor.getData())[0][0]);
+        assertEquals(0, ((int[][]) hourofdayTensor.getData())[0][0]);
+        assertEquals(0, ((int[][]) minuteofhourTensor.getData())[0][0]);
+        assertEquals(1, ((int[][]) dayofweekTensor.getData())[0][0]);
+        assertEquals("2018", ((String[][]) yearString.getData())[0][0]);
+        assertEquals(2018.0, ((float[][]) yearFloat.getData())[0][0]);
+        assertEquals(1514764800L, ((long[][]) timestampSeconds.getData())[0][0]);
+        assertEquals(48L, ((long[][]) timestampYears.getData())[0][0]);
+
+        assertEquals(2019, ((int[][]) yearTensor.getData())[1][0]);
+        assertEquals(12, ((int[][]) monthTensor.getData())[1][0]);
+        assertEquals(31, ((int[][]) dayOfMonthTensor.getData())[1][0]);
+        assertEquals(23, ((int[][]) hourofdayTensor.getData())[1][0]);
+        assertEquals(59, ((int[][]) minuteofhourTensor.getData())[1][0]);
+        assertEquals(2, ((int[][]) dayofweekTensor.getData())[1][0]);
+        assertEquals(2019.0, ((float[][]) yearFloat.getData())[1][0]);
+        assertEquals(1577836799L, ((long[][]) timestampSeconds.getData())[1][0]);
+        assertEquals(49L, ((long[][]) timestampYears.getData())[1][0]);
+    }
+
+}

--- a/evaluator-timeseries/src/test/resources/timeseries/datetime-string-manifest.json
+++ b/evaluator-timeseries/src/test/resources/timeseries/datetime-string-manifest.json
@@ -1,0 +1,72 @@
+{
+  "inputs": [
+    {
+      "name": "date",
+      "type": "string",
+      "shape": "(-1, -1)",
+      "format": "yyyy-MM-dd HH:mm:ss"
+    }
+  ],
+  "outputs": [
+    {
+      "name": "year",
+      "type": "integer",
+      "shape": "(-1, -1)",
+      "format": "YEAR"
+    },
+    {
+      "name": "month",
+      "type": "integer",
+      "shape": "(-1, -1)",
+      "format": "MONTH"
+    },
+    {
+      "name": "dayofmonth",
+      "type": "integer",
+      "shape": "(-1, -1)",
+      "format": "DAYOFMONTH"
+    },
+    {
+      "name": "hourofday",
+      "type": "integer",
+      "shape": "(-1, -1)",
+      "format": "HOUROFDAY"
+    },
+    {
+      "name": "minuteofhour",
+      "type": "integer",
+      "shape": "(-1, -1)",
+      "format": "MINUTEOFHOUR"
+    },
+    {
+      "name": "dayofweek",
+      "type": "integer",
+      "shape": "(-1, -1)",
+      "format": "DAYOFWEEK"
+    },
+    {
+      "name": "year-string",
+      "type": "string",
+      "shape": "(-1, -1)",
+      "format": "yyyy"
+    },
+    {
+      "name": "year-float",
+      "type": "float",
+      "shape": "(-1, -1)",
+      "format": "YEAR"
+    },
+    {
+      "name": "timestamp-seconds",
+      "type": "long",
+      "shape": "(-1, -1)",
+      "format": "TS_S"
+    },
+    {
+      "name": "timestamp-years",
+      "type": "long",
+      "shape": "(-1, -1)",
+      "format": "TS_Y"
+    }
+  ]
+}

--- a/evaluator-timeseries/src/test/resources/timeseries/datetime-timestamp-manifest.json
+++ b/evaluator-timeseries/src/test/resources/timeseries/datetime-timestamp-manifest.json
@@ -1,0 +1,18 @@
+{
+  "inputs": [
+    {
+      "name": "timestamp-seconds",
+      "type": "long",
+      "shape": "(-1, -1)",
+      "format": "TS_S"
+    }
+  ],
+  "outputs": [
+    {
+      "name": "date",
+      "type": "string",
+      "shape": "(-1, -1)",
+      "format": "yyyy-MM-dd HH:mm:ss"
+    }
+  ]
+}


### PR DESCRIPTION
Add a specific evaluator for Datetime interpretation : 

Example of json manifest : 

```json
{
  "inputs": [
    {
      "name": "date",
      "type": "string",
      "shape": [-1, -1],
      "format": "yyyy-MM-dd"
    }
  ],
  "outputs": [
    {
      "name": "year",
      "type": "integer",
      "shape": [-1, -1],
      "format": "YEAR"
    },
    {
      "name": "month",
      "type": "integer",
      "shape": [-1, -1],
      "format": "MONTH"
    },
    {
      "name": "dayofmonth",
      "type": "integer",
      "shape": [-1, -1],
      "format": "DAYOFMONTH"
    } ]
}
```

The type of the new evaluator is `datetime_encoder`. It should only contains one input field which is the date to encode or decode.

If the input date field is a `string` the `format` property should be filled with the datetime formatter to use for conversion.
If the input date field is a numeric type the `format` property should be filled accordingly to the following : 

* `YEAR` : Numeric representation of the year
* `MONTH` : Numeric representation of the month
* `DAYOFMONTH` : Numeric representation of the day of the month
* `DAYOFWEEK` : Numeric representation of the day of the week
* `HOUROFDAY` : Numeric representation of the hour of the day
* `MINUTEOFHOUR` : Numeric representation of the minute of the hour
* `TS_Y` : Timestamp UTC in years
* `TS_MO` : Timestamp UTC in months
* `TS_D` : Timestamp UTC in days
* `TS_H` : Timestamp UTC in hours
* `TS_MI` : Timestamp UTC in minutes
* `TS_S` : Timestamp UTC in seconds
* `TS_MS` : Timestamp UTC in millis-seconds
* `TS_US` : Timestamp UTC in micros-seconds
* `TS_NS` : Timestamp UTC in nanos-seconds