### PR TITLE
[BUGFIX] Replace 'pip3' and 'python3' links

### DIFF
--- a/evaluator-tensorflow/h5_converter/Makefile
+++ b/evaluator-tensorflow/h5_converter/Makefile
@@ -4,5 +4,5 @@ WORKDIR := $(dir $(realpath $(firstword $(MAKEFILE_LIST))))
 
 .PHONY: build
 build:
-	pip3 install -r requirements.txt
-	bash -c "pyinstaller --clean --additional-hooks-dir=./hooks -F h5_converter.py --log-level=INFO --add-data $$(python3 -c 'import os;import astor;print(os.path.dirname(astor.__file__))')/VERSION:astor/"
+	pip install -r requirements.txt
+	bash -c "pyinstaller --clean --additional-hooks-dir=./hooks -F h5_converter.py --log-level=INFO --add-data $$(python -c 'import os;import astor;print(os.path.dirname(astor.__file__))')/VERSION:astor/"


### PR DESCRIPTION
Replace 'pip3' and 'python3' links with simple 'pip' and 'python' for more genericity