### PR TITLE
Crannou/fix/bump version cve

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -17,7 +17,7 @@
         <guice.version>4.2.2</guice.version>
         <typesafe-guice.version>0.1.0</typesafe-guice.version>
         <resteasy.version>4.1.1.Final</resteasy.version>
-        <log4j2.version>2.7</log4j2.version>
+        <log4j2.version>2.14.0</log4j2.version>
         <metrics.version>0.5.0</metrics.version>
         <swagger-jaxrs2.version>2.0.9</swagger-jaxrs2.version>
 

--- a/evaluator-tensorflow/h5_converter/requirements.txt
+++ b/evaluator-tensorflow/h5_converter/requirements.txt
@@ -1,4 +1,5 @@
-tensorflow==1.15.2
+tensorflow==1.15.4
 pyinstaller>=3.5,<=3.6
 absl-py==0.8.1
 setuptools>=41.0.1,<45.0.0
+h5py==2.10.0


### PR DESCRIPTION
Bump versions to handle CVE detected by `dependabot`.

Fix `h5py` version to fix `h5_converter` generation